### PR TITLE
Make Developer Created AWSSignInProvider possible.

### DIFF
--- a/AWSMobileHubHelper/Identity/AWSIdentityManager.h
+++ b/AWSMobileHubHelper/Identity/AWSIdentityManager.h
@@ -45,6 +45,23 @@ FOUNDATION_EXPORT NSString *const AWSIdentityManagerDidSignOutNotification;
 @property (nonatomic, readonly, nullable) NSString *identityId;
 
 /**
+ * Some processes in a mobile app require access to the currentSignInProvider.
+ * For example with custom OpenIdConnect or CognitoUserPools providers you may
+ * need to have access to the provider in order to sign-up a user, or recall a forgotten
+ * password.  For Google and Facebook you may need the provider in order to access
+ * user claims.  Thus we expose the (read only) currentSignInProvider
+ * @return currentSignInProvider
+ */
+@property (nonatomic, readonly) id currentSignInProvider;
+
+/**
+ * Completes login process, sends notification of SignIn state change
+ * clears cached temporary credentials and gets credentials. Once the
+ * AWSSignInProvider completes the login, it must call completLogin
+ */
+- (void)completeLogin;
+
+/**
  Returns the Identity Manager singleton instance configured using the information provided in `Info.plist` file.
  
  *Swift*
@@ -72,6 +89,19 @@ FOUNDATION_EXPORT NSString *const AWSIdentityManagerDidSignOutNotification;
 - (void)loginWithSignInProvider:(id<AWSSignInProvider>)signInProvider
               completionHandler:(void (^)(id _Nullable result, NSError * _Nullable error))completionHandler;
 
+/**
+ * The providerKey is a user readable name of the signInProvider passed as an such 
+ * as Facebook or Google or whatever you choose for your developer identity provider 
+ * or cognito user pools. The name is used as the key for the NSUserDefaults Active
+ * Session indicator. This value is needed for user feedback (for instance a Cognito login
+ * error can say "Failed to login to Cognito Pool" instead of "Failed to login 
+ * to cognito-idp.us-east-1_KRlVhYCpHqM", which is much less user friendly.
+ * Keys are used as user friendly name AND to maintain active sessions.
+ * The keys are established using Info.Plist under 
+ * AWS->IdentityManager->Default->SignInProviderKeyDictionary
+ * @return provider name or nil (nil if classname not found)
+ */
+- (NSString *)providerKey:(id<AWSSignInProvider>)signInProvider;
 
 /**
  * Attempts to resume session with the previous sign-in provider.


### PR DESCRIPTION
Required changes so that AWSSignInProviders can be created and installed.

Allow any number of AWSSignInProviders to maintain sessions and have them
restarted by interceptApplication didFinishLaunchinWithOptions. Without
this fix, only Google and Facebook sessions are restarted. This behavior
is accomplished by a configuration in Info.plist.  If it is missing
prior behaviour with hardcoded Facebook and Google providers is maintained.
This allows Mobile Hub applications to run with no changes to Info.plist.

The configuration relates class names (used to instantiate the singletons)
with user friendly names (used for NSUserDefaultsKeys and for human
readable provider names. The dictionary is located in
AWS->IdentityManager->Default->SignInProviderClassDictionary
and has a form like this:

<key>SignInProviderKeyDictionary</key>
	<dict>
		<key>AWSCUPIdPSignInProvider</key><string>Cognito Pool</string>
		<key>AWSFacebookSignInProvider</key><string>Facebook</string>
		<key>AWSGoogleSignInProvider</key><string>Google</string>
	</dict>

Additionally this fix:

1) Exposes currentSignInProvider, this is necessary so that apps can
determine which provider is active and call it's methods to get access
to properties needed for developer identities and Cognito (your) user pools
(including the ability to get access to the pool).

2) Creates new AWSIdentityManager method providerKey to return the
"Visible" name of an AWSSignInProvider so that the user may be prompted or
notified of which provider is involved (for login errors,
provider lists, etc.).

3) Expose completeLogin. Once the AWSSignInProvider completes the login,
it must call completeLogin, however that method is private.