### PR TITLE
AWSFacebookSignInProvider fails to call completion handler in loginWithCompletionHandler

### DIFF
--- a/AWSMobileHubHelper/SignIn/AWSFacebookSignInProvider.m
+++ b/AWSMobileHubHelper/SignIn/AWSFacebookSignInProvider.m
@@ -205,7 +205,11 @@ typedef void (^AWSIdentityManagerCompletionBlock)(id result, NSError *error);
                                                  //[[AWSIdentityManager errorAlert:[NSString stringWithFormat:@"Error logging in with FB: %@", error.localizedDescription]] show];
                                                  self.completionHandler(result, error);
                                              } else if (result.isCancelled) {
-                                                 // Login canceled, do nothing
+                                                 // Login canceled, allow completionhandler to know about it
+                                                 NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
+                                                 userInfo[@"message"] = @"User Cancelled Login";
+                                                 NSError *resultError = [NSError errorWithDomain:FBSDKLoginErrorDomain code:FBSDKLoginUnknownErrorCode userInfo:userInfo];
+                                                 self.completionHandler(result,resultError);
                                              } else {
                                                  [self completeLogin];
                                              }


### PR DESCRIPTION
AWSFacebookSignInProvider does not call the completion handler when
loginWithCompletionHandler is called if the user presses "Cancel" or "Done".
The code at that point has a comment: // Login canceled, do nothing

This change adds the needed call to the completion handler passing
an error and no result.  The error is: FBSDKLoginUnknownErrorCode
The user info is: "User Cancelled Login"

This error is then (typically - not by mobile hub) displayed to the user.
This is almost exactly how the AWSGoogleSignInProvider behaves, and is
as it should be.

Without this fix behavior on login is different for google and facebook,
and the session state of AWSIdentityManager cannot be maintained

This fix does not require and is independent of the other pull requests.