### PR TITLE
AWSIdentityManager allow identity merging and fix hang

### DIFF
--- a/AWSMobileHubHelper/Identity/AWSIdentityManager.h
+++ b/AWSMobileHubHelper/Identity/AWSIdentityManager.h
@@ -45,6 +45,23 @@ FOUNDATION_EXPORT NSString *const AWSIdentityManagerDidSignOutNotification;
 @property (nonatomic, readonly, nullable) NSString *identityId;
 
 /**
+ * Some processes in a mobile app require access to the currentSignInProvider.
+ * For example with custom OpenIdConnect or CognitoUserPools providers you may
+ * need to have access to the provider in order to sign-up a user, or recall a forgotten
+ * password.  For Google and Facebook you may need the provider in order to access
+ * user claims.  Thus we expose the (read only) currentSignInProvider
+ * @return currentSignInProvider
+ */
+@property (nonatomic, readonly) id currentSignInProvider;
+
+/**
+ * Completes login process, sends notification of SignIn state change
+ * clears cached temporary credentials and gets credentials. Once the
+ * AWSSignInProvider completes the login, it must call completLogin
+ */
+- (void)completeLogin;
+
+/**
  Returns the Identity Manager singleton instance configured using the information provided in `Info.plist` file.
  
  *Swift*
@@ -72,6 +89,19 @@ FOUNDATION_EXPORT NSString *const AWSIdentityManagerDidSignOutNotification;
 - (void)loginWithSignInProvider:(id<AWSSignInProvider>)signInProvider
               completionHandler:(void (^)(id _Nullable result, NSError * _Nullable error))completionHandler;
 
+/**
+ * The providerKey is a user readable name of the signInProvider passed as an such 
+ * as Facebook or Google or whatever you choose for your developer identity provider 
+ * or cognito user pools. The name is used as the key for the NSUserDefaults Active
+ * Session indicator. This value is needed for user feedback (for instance a Cognito login
+ * error can say "Failed to login to Cognito Pool" instead of "Failed to login 
+ * to cognito-idp.us-east-1_KRlVhYCpHqM", which is much less user friendly.
+ * Keys are used as user friendly name AND to maintain active sessions.
+ * The keys are established using Info.Plist under 
+ * AWS->IdentityManager->Default->SignInProviderKeyDictionary
+ * @return provider name or nil (nil if classname not found)
+ */
+- (NSString *)providerKey:(id<AWSSignInProvider>)signInProvider;
 
 /**
  * Attempts to resume session with the previous sign-in provider.

--- a/AWSMobileHubHelper/Identity/AWSIdentityManager.h
+++ b/AWSMobileHubHelper/Identity/AWSIdentityManager.h
@@ -55,6 +55,16 @@ FOUNDATION_EXPORT NSString *const AWSIdentityManagerDidSignOutNotification;
 @property (nonatomic, readonly) id currentSignInProvider;
 
 /**
+ * Returns an array of instances of AWSSignInProviders with active sessions.
+ * SignIn Providers that have active sessions store a value in NSUserDefaults with thier
+ * providerKey as a key.  Usually this value is "YES", but does not need to be (some have
+ * stored a token).  The existence of any value is enough to indicate that there is an
+ * active session with this provider.
+ * @return NSArray of active AWSSignInProvider instances
+ */
+- (NSArray *)activeProviders;
+
+/**
  * Completes login process, sends notification of SignIn state change
  * clears cached temporary credentials and gets credentials. Once the
  * AWSSignInProvider completes the login, it must call completLogin

--- a/AWSMobileHubHelper/Identity/AWSIdentityManager.m
+++ b/AWSMobileHubHelper/Identity/AWSIdentityManager.m
@@ -29,12 +29,18 @@ typedef void (^AWSIdentityManagerCompletionBlock)(id result, NSError *error);
 
 @implementation AWSIdentityManager
 
+// Enhancement support
+NSDictionary<NSString *, NSString *> *loginCache; // Be a "real" AWSIdentityProviderManager
+BOOL mergingIdentityProviderManager; // Switch to allow or reject identity merging
+BOOL multiAccountIdentityProviderManager; // Switch to allow or reject stacked logins
 BOOL doNotInitProviders; // Switch true if last shutdown was graceless
 
 static NSString *const AWSInfoIdentityManager = @"IdentityManager";
 static NSString *const AWSInfoRoot = @"AWS";
 static NSString *const AWSInfoMobileHub = @"MobileHub";
 static NSString *const AWSInfoProjectClientId = @"ProjectClientId";
+static NSString *const AWSInfoAllowIdentityMerging = @"Allow Identity Merging";
+static NSString *const AWSInfoAllowSimultaneousActiveAccounts = @"Allow Simultaneous Active Accounts";
 
 + (instancetype)defaultIdentityManager {
     static AWSIdentityManager *_defaultIdentityManager = nil;
@@ -48,9 +54,18 @@ static NSString *const AWSInfoProjectClientId = @"ProjectClientId";
                                          userInfo:nil];
         }
         _defaultIdentityManager = [[AWSIdentityManager alloc] initWithCredentialProvider:serviceInfo];
+        loginCache = [[NSDictionary<NSString *, NSString *> alloc] init];
+        if (!(mergingIdentityProviderManager = [[serviceInfo.infoDictionary valueForKey:AWSInfoAllowIdentityMerging] boolValue])) {
+            mergingIdentityProviderManager = FALSE; // Mobile Hub Compatibility
+        };
+        if (!(multiAccountIdentityProviderManager =  [[serviceInfo.infoDictionary valueForKey:AWSInfoAllowSimultaneousActiveAccounts  ] boolValue])) {
+            multiAccountIdentityProviderManager = FALSE; // Mobile Hub Compatibility
+        };
         if ((doNotInitProviders = ![[NSUserDefaults standardUserDefaults] boolForKey:AWSIdentityManagerUserDefaultsProvidersOk])) {
             NSLog(@"Graceless exit detected");
         };
+
+
     });
     
     return _defaultIdentityManager;
@@ -81,8 +96,30 @@ static NSString *const AWSInfoProjectClientId = @"ProjectClientId";
     }
     return [[self.currentSignInProvider token] continueWithSuccessBlock:^id _Nullable(AWSTask<NSString *> * _Nonnull task) {
         NSString *token = task.result;
-        return [AWSTask taskWithResult:@{self.currentSignInProvider.identityProviderName : token}];
+        [self mergeLogins:@{self.currentSignInProvider.identityProviderName : token}];
+        return [AWSTask taskWithResult: loginCache];
     }];
+}
+
+- (void)mergeLogins:(NSDictionary<NSString *,NSString *> *)logins {
+    if (!mergingIdentityProviderManager) {
+        loginCache = [logins copy]; // not merging?  replace the cache with what they passed
+    } else { // merging, add the new login to the cache
+        NSMutableDictionary<NSString *, NSString *> *merge = [[NSMutableDictionary<NSString *, NSString *> alloc] init];
+        merge = [loginCache mutableCopy];
+
+        for (NSString* key in logins) {
+            merge[key] = logins[key];
+        }
+        loginCache = [merge copy];
+    }
+}
+
+- (void)dropLogin:(NSString *)key {
+    NSMutableDictionary<NSString *, NSString *> *shorterList = [[NSMutableDictionary<NSString *, NSString *> alloc] init];
+    shorterList = [loginCache mutableCopy];
+    [shorterList removeObjectForKey: key];
+    loginCache = [shorterList copy];
 }
 
 #pragma mark -
@@ -116,6 +153,9 @@ static NSString *const AWSInfoProjectClientId = @"ProjectClientId";
 }
 
 - (void)wipeAll {
+    if (self.currentSignInProvider) { // fix login cache
+        [self dropLogin: [self.currentSignInProvider identityProviderName]];
+    }
     [self.credentialsProvider clearKeychain];
 }
 
@@ -149,10 +189,33 @@ static NSString *const AWSInfoProjectClientId = @"ProjectClientId";
 
 - (void)loginWithSignInProvider:(id)signInProvider
               completionHandler:(void (^)(id result, NSError *error))completionHandler {
+
+    // don't create multiple logins if the Allow Simultaneous Active Accounts is NO
+    if (!multiAccountIdentityProviderManager  && self.currentSignInProvider) {
+        [self logoutWithCompletionHandler:^void (id result, NSError *error) {
+            if ( error != nil ) {
+                NSLog( @"Error from logoutWithCompletionHandler %@", error);
+            }
+        }];
+    }
+    // allow multiple logins but don't merge the list
+    if (multiAccountIdentityProviderManager && !mergingIdentityProviderManager) {
+        // in this case, we don't want to let the credentials provider retry till he decides
+        // to do a getcredentials, instead we wipe and force it.
+        // This allows multiple stacked logins without merging
+        [self wipeAll];
+    }
     self.currentSignInProvider = signInProvider;
     
     self.completionHandler = completionHandler;
-    [self.currentSignInProvider login:completionHandler];
+    [self.currentSignInProvider login:^void (id result, NSError *error) {
+        if ( error != nil ) {
+            // catch the completion handler so we can do some housekeeping
+            // so we don't leave currentSignInProvider as wrong provider
+            self.currentSignInProvider = nil;
+        }
+        self.completionHandler(result,error);
+    }];
 }
 //              (^AWSIdentityManagerCompletionBlock)(id result, NSError *error)
 - (void)resumeSessionWithCompletionHandler:(AWSIdentityManagerCompletionBlock)completionHandler {
@@ -190,7 +253,19 @@ static NSString *const AWSInfoProjectClientId = @"ProjectClientId";
                 AWSLogError(@"Fatal exception: [%@]", task.exception);
                 kill(getpid(), SIGKILL);
             }
-            self.completionHandler(task.result, task.error);
+            // Cannot merge identities is a failed login, not logging in with another
+            // provider.  And this or any other error causes us to logout and
+            // go look for other sessions to start.
+            if (task.error.code == AWSCognitoIdentityErrorResourceConflict || task.error != nil) {
+                [self logoutWithCompletionHandler:^void (id result, NSError *error) {
+                    if ( error != nil ) {
+                        NSLog( @"Error from logoutWithCompletionHandler %@", error);
+                    }
+                    self.completionHandler(task.result, task.error); // done deliver result
+                }];
+            } else {
+                self.completionHandler(task.result, task.error);  // no issues
+            }
         });
         return nil;
     }];


### PR DESCRIPTION
    Allow merging of identities
    Allow multiple identity merging and simultaneous authenticated identities

    Fix AWSIdentityManager so that it tracks logins in a cache and allows
    Cognito identity merging.

    Controlled using flags set in Info.plist, this allows the developer to choose
    how the identityId's are managed.

    To ensure Mobile Hub compatibility, if there are no flags in the Info.plist behavior is like that of the
    existing library (except for one fix, because the current AWSIdentityManager
    lets you log in to a second identity, gets an error, gets stuck, and has to
    be restarted to get rid of it.  More on this below.).

    The flags are stored in AWS->IdentityManager->Default and are as follows:
    <key>IdentityManager</key>
      <dict>
        <key>Default</key>
          <dict>
            <key>Allow Identity Merging</key><true/>
            <key>Allow Simultaneous Active Accounts</key><true/>

    Legal values are
    TRUE TRUE   - allow both merging and simultaneous active accounts
    FALSE TRUE  - allow simultaneous stacked logins but don't merge
                  (never returns a merged logins dictionary)
    FALSE FALSE - allow one login at a time, any new login
                  logs the previous identity out.
                  This fixes a current bug see below.

    This setting is not legal
    FALSE TRUE - Merging identities requires at least two simultaneous logins

    Current AWSIdentityManager bug.
    If you login twice, each login is independent, they do not merge,
    and when you log out of one, you find yourself back logged in as the other
    (different) identityId.

    This feels strange to the user, and does not really work (I think
    because the credentials are not associated with the new identity on
    logout (only on login).  At this point you get a whole bunch of logged
    errors, and it does not recover gracefully from this condition.

    The errors say "GetCredentialsForIdentity keeps failing. Clearing
    identityId did not help. Please check your Amazon Cognito Identity
    configuration."

    But the problem is not that the configuration is bad, it is that
    AWSIdentityManager mis-handles the logout so that the identityId remains
    old, while the logins dictionary is new.

    This fix no longer allows this condition regardless of settings.
    (If you are not allowing merging, then logging in one user is made to
    log out the other first, invisibly and automatically.)
